### PR TITLE
Atualização da seção de Cursos e Codelabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,11 @@ Lembrando: esse repositório é uma iniciativa do [Android Dev BR](https://githu
 ### Cursos e Codelabs Online 👨🏾‍💻 👩🏻‍💻
 
 | **Nome**  | **Descrição** | **Idioma** | **Link** | 
-| - | - | - | - | - |
+| - | - | - | - |
 | Formação Android - Alura | Curso de formação de profissionais Android fornecido pela Alura, serviço de cursos online da Caelum | 🇧🇷 | [Link](http://bit.do/eSUaP) |
 | Caster.io | Curso online avançado para profissionais Android, com professores membros da comunidade e do programa de Experts do Google (GDEs) | 🇬🇧 | [Link](http://bit.do/eSUaU) |
-| Codelabs Android - Google Developers | Codelabs oficiais de Android, mantidos pelo Google | 🇬🇧 | [Link](http://bit.do/eSUaZ) |
-| Android Kotlin Fundamentals - Google Developers | Codelab sobre Fundamentos de Android em Kotlin, mantidos pelo Google | 🇬🇧 | [Link](http://bit.do/fH4pK) |
-| Fundamentos de Android para Kotlin - Adaptado e Traduzido | Codelab sobre Fundamentos de Android em Kotlin, desenvolvido pela Google, adaptado e traduzido pela comunidade | 🇧🇷 | [Link](http://bit.do/fH4qf) |
+| Codelabs Android - Google Developers | Codelabs oficiais de Android, mantidos pelo Google | 🇬🇧 | [Link](https://developer.android.com/courses)|
+| Fundamentos de Android em Kotlin | Codelabs de Android, adaptados dos Codelabs oficiais | 🇧🇷 | [Link](https://pertence.net/android-kotlin-guide/kotlin-android-training-welcome.html)
 | Developing Android Apps with Kotlin - Udacity| Curso oficial do Google, fornecido pela Udacity, ensinando a desenvolver em Kotlin e utilizando Android Architecture Components | 🇬🇧 | [Link](https://www.udacity.com/course/developing-android-apps-with-kotlin--ud9012#) |
 | Kotlin Hands-On | Codelabs diversos sobre recursos da linguagem, incluindo Coroutines, Kotlin Multiplatform e Kotlin Native | 🇬🇧 | [Link](https://play.kotlinlang.org/hands-on/overview) |
 

--- a/README.md
+++ b/README.md
@@ -80,10 +80,12 @@ Lembrando: esse repositório é uma iniciativa do [Android Dev BR](https://githu
 ### Cursos e Codelabs Online 👨🏾‍💻 👩🏻‍💻
 
 | **Nome**  | **Descrição** | **Idioma** | **Link** | 
-| - | - | - | - | 
+| - | - | - | - | - |
 | Formação Android - Alura | Curso de formação de profissionais Android fornecido pela Alura, serviço de cursos online da Caelum | 🇧🇷 | [Link](http://bit.do/eSUaP) |
 | Caster.io | Curso online avançado para profissionais Android, com professores membros da comunidade e do programa de Experts do Google (GDEs) | 🇬🇧 | [Link](http://bit.do/eSUaU) |
 | Codelabs Android - Google Developers | Codelabs oficiais de Android, mantidos pelo Google | 🇬🇧 | [Link](http://bit.do/eSUaZ) |
+| Android Kotlin Fundamentals - Google Developers | Codelab sobre Fundamentos de Android em Kotlin, mantidos pelo Google | 🇬🇧 | [Link](http://bit.do/fH4pK) |
+| Fundamentos de Android para Kotlin - Adaptado e Traduzido | Codelab sobre Fundamentos de Android em Kotlin, desenvolvido pela Google, adaptado e traduzido pela comunidade | 🇧🇷 | [Link](http://bit.do/fH4qf) |
 | Developing Android Apps with Kotlin - Udacity| Curso oficial do Google, fornecido pela Udacity, ensinando a desenvolver em Kotlin e utilizando Android Architecture Components | 🇬🇧 | [Link](https://www.udacity.com/course/developing-android-apps-with-kotlin--ud9012#) |
 | Kotlin Hands-On | Codelabs diversos sobre recursos da linguagem, incluindo Coroutines, Kotlin Multiplatform e Kotlin Native | 🇬🇧 | [Link](https://play.kotlinlang.org/hands-on/overview) |
 


### PR DESCRIPTION
A primeira mudança é sobre o link bit.do/eSUaU, que redireciona para codelabs.developers.google.com/?cat=Android, onde há os codelabs estão listados de forma individual. O novo link developer.android.com/courses contém os codelabs em forma de curso.

A segunda mudança é a inclusão de uma adaptação de um codelabs do Google para português.